### PR TITLE
Pequeños ajustes y mejoras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: ci
 on:
-  push:
-    branches: [ rolling ]
   pull_request:
     branches: [ rolling ]
     paths-ignore:
@@ -19,8 +17,6 @@ jobs:
     name: "Test with Node v${{ matrix.node }}"
     runs-on: ubuntu-latest
     strategy:
-      # TODO: Check this
-      #max-parallel: 1
       fail-fast: false
       matrix:
         node: [ 16.x, 18.x ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
   coverage:
     name: Upload coverage
-    needs: [ test, analyse ]
+    needs: [ test ]
     runs-on: ubuntu-latest
 
     if: always() && github.repository_owner == 'jspaste'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on:
   pull_request:
     branches: [ rolling ]
     paths-ignore:
-      - '*.md'
-      - '.gitattributes'
-      - '.gitignore'
+      - "*.md"
+      - ".gitattributes"
+      - ".gitignore"
 
 permissions:
   actions: read
@@ -19,7 +19,8 @@ jobs:
     name: "Test with Node v${{ matrix.node }}"
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      # TODO: Check this
+      #max-parallel: 1
       fail-fast: false
       matrix:
         node: [ 16.x, 18.x ]
@@ -39,7 +40,7 @@ jobs:
       - name: Cheking tests...
         run: npm run test
 
-      - if: always() && github.repository_owner == 'jspaste'
+      - if: always() && github.repository_owner == "jspaste"
         name: Saving coverage...
         uses: actions/upload-artifact@v3
         with:
@@ -51,7 +52,7 @@ jobs:
     name: Analysis
     runs-on: ubuntu-latest
 
-    if: github.repository_owner == 'jspaste'
+    if: github.repository_owner == "jspaste"
     steps:
       - uses: actions/checkout@v3
 
@@ -61,18 +62,6 @@ jobs:
           languages: javascript
           queries: security-extended,security-and-quality
 
-      - name: Warming up (node)
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-          cache: npm
-
-      - name: Warming up (deps)
-        run: npm ci
-
-      - name: Building...
-        run: npm run build
-
       - name: Analysing code...
         uses: github/codeql-action/analyze@v2
 
@@ -81,7 +70,7 @@ jobs:
     needs: [ test, analyse ]
     runs-on: ubuntu-latest
 
-    if: always() && github.repository_owner == 'jspaste'
+    if: always() && github.repository_owner == "jspaste"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: ci
 on:
+  push:
+    branches: [ rolling ]
   pull_request:
     branches: [ rolling ]
     paths-ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Cheking tests...
         run: npm run test
 
-      - if: always() && github.repository_owner == "jspaste"
+      - if: always() && github.repository_owner == 'jspaste'
         name: Saving coverage...
         uses: actions/upload-artifact@v3
         with:
@@ -52,7 +52,7 @@ jobs:
     name: Analysis
     runs-on: ubuntu-latest
 
-    if: github.repository_owner == "jspaste"
+    if: github.repository_owner == 'jspaste'
     steps:
       - uses: actions/checkout@v3
 
@@ -70,7 +70,7 @@ jobs:
     needs: [ test, analyse ]
     runs-on: ubuntu-latest
 
-    if: always() && github.repository_owner == "jspaste"
+    if: always() && github.repository_owner == 'jspaste'
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     name: Publish JSPaste
     runs-on: ubuntu-latest
 
-    if: github.repository_owner == "jspaste"
+    if: github.repository_owner == 'jspaste'
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     name: Publish JSPaste
     runs-on: ubuntu-latest
 
-    if: github.repository_owner == 'jspaste'
+    if: github.repository_owner == "jspaste"
     steps:
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![](https://flat.badgen.net/npm/v/jspaste)](https://www.npmjs.com/package/jspaste)
 [![](https://flat.badgen.net/npm/dt/jspaste)](https://www.npmjs.com/package/jspaste)
-[![](https://badgen.net/codecov/c/github/jspaste/jspaste/rolling)](https://app.codecov.io/gh/jspaste/jspaste)
+[![](https://flat.badgen.net/codecov/c/github/jspaste/jspaste)](https://app.codecov.io/gh/jspaste/jspaste)
 [![](https://flat.badgen.net/packagephobia/install/jspaste)](https://packagephobia.com/result?p=jspaste)
 [![](https://flat.badgen.net/bundlephobia/minzip/jspaste)](https://bundlephobia.com/package/jspaste)
 
@@ -45,7 +45,7 @@ book, have a look at our [documentation](https://paka.dev/npm/jspaste).
 
 ### Example
 
-With [**ESModules**](https://nodejs.org/api/esm.html#modules-ecmascript-modules)
+With [**ESModules**](https://nodejs.org/api/esm.html#modules-ecmascript-modules):
 
 ```js
 import JSP from "jspaste";
@@ -53,7 +53,7 @@ import JSP from "jspaste";
 new JSP().access("ujcbfrryaqoclfea").then(console.info);
 ```
 
-With [**CommonJS**](https://nodejs.org/api/modules.html#modules-commonjs-modules)
+With [**CommonJS**](https://nodejs.org/api/modules.html#modules-commonjs-modules):
 
 ```js
 const JSP = require("jspaste");

--- a/lib/JSP.ts
+++ b/lib/JSP.ts
@@ -12,7 +12,7 @@ import {Request} from "./Request";
  * console.info(await jsp.access("foo"));
  * jsp.access("foobar").then(x => { ... });
  */
-export class JSP {
+export default class JSP {
     /**
      * Publish "something" to the API (E.g. server logs, error dumps or configs which need to be backed up temporarily in the cloud for later access)
      *
@@ -29,7 +29,6 @@ export class JSP {
      * // > I am interested in printing this onto the terminal
      * console.info({ ack.res.url, ack.res.resource, ack.res.secret });
      * @param {any} payload Data to upload
-     * @return {Promise<IPublishRes>}
      */
     public async publish(payload: any): Promise<IPublishRes> {
         const res = await new Request(api + api_route.documents).publish(String(payload));
@@ -64,7 +63,6 @@ export class JSP {
      * // > I am interested in printing this onto the terminal
      * console.info({ ack.res.payload });
      * @param {string} resource Resource identifier
-     * @return {Promise<IAccessRes>}
      */
     public async access(resource: string): Promise<IAccessRes> {
         const res = await new Request(api + api_route.documents).access(resource);
@@ -96,7 +94,6 @@ export class JSP {
      * else console.info("Resource removal failed.");
      * @param {string} resource Resource identifier
      * @param {string} secret Owner key which verifies the ownership of a "resource" in the API
-     * @return {Promise<IRemoveRes>}
      */
     public async remove(resource: string, secret: string): Promise<IRemoveRes> {
         const res = await new Request(api + api_route.documents).remove(resource, secret);

--- a/lib/JSP.ts
+++ b/lib/JSP.ts
@@ -32,7 +32,6 @@ export default class JSP {
      */
     public async publish(payload: any): Promise<IPublishRes> {
         const res = await new Request(api + api_route.documents).publish(String(payload));
-        const body = await res.json();
 
         return {
             req: {
@@ -40,10 +39,10 @@ export default class JSP {
                 payload: payload
             },
             res: {
-                url: api + body.key,
-                raw: body,
-                resource: body.key,
-                secret: body.secret
+                url: api + res.body.key,
+                raw: res.body,
+                resource: res.body.key,
+                secret: res.body.secret
             }
         }
     }
@@ -66,7 +65,6 @@ export default class JSP {
      */
     public async access(resource: string): Promise<IAccessRes> {
         const res = await new Request(api + api_route.documents).access(resource);
-        const body = await res.json();
 
         return {
             req: {
@@ -75,8 +73,8 @@ export default class JSP {
             },
             res: {
                 url: api + resource,
-                raw: body,
-                payload: body.data
+                raw: res.body,
+                payload: res.body.data
             }
         }
     }
@@ -97,7 +95,6 @@ export default class JSP {
      */
     public async remove(resource: string, secret: string): Promise<IRemoveRes> {
         const res = await new Request(api + api_route.documents).remove(resource, secret);
-        const body = await res.json();
 
         return {
             req: {
@@ -106,7 +103,7 @@ export default class JSP {
                 secret: secret
             },
             res: {
-                raw: body
+                raw: res.body
             }
         }
     }

--- a/lib/Request.ts
+++ b/lib/Request.ts
@@ -14,19 +14,20 @@ export class Request extends JSPHTTP {
         super(api_url, options);
     }
 
-    public readonly publish = (payload: any): Promise<Response> => this.customs(super.run("POST", undefined, undefined, payload));
-    public readonly access = (resource: string): Promise<Response> => this.customs(super.run("GET", resource));
-    public readonly remove = (resource: string, secret: string): Promise<Response> => this.customs(super.run("DELETE", resource, secret));
+    public readonly publish = (payload: any) => this.customs(super.run("POST", undefined, undefined, payload));
+    public readonly access = (resource: string) => this.customs(super.run("GET", resource));
+    public readonly remove = (resource: string, secret: string) => this.customs(super.run("DELETE", resource, secret));
 
-    private async customs(responsePromise: Promise<Response>): Promise<Response> {
+    private async customs(responsePromise: Promise<Response>) {
         const response = await responsePromise;
 
-        try {
-            JSON.parse(await response.text())
-        } catch (e) {
+        await response.json().catch(() => {
             throw new JSPError("APIError", msg.err.API_INVALID_RESPONSE, msg.err.API_INVALID_RESPONSE_EXTRA);
-        }
+        })
 
-        return response;
+        return {
+            ...response,
+            body: await response.json()
+        }
     }
 }

--- a/lib/bank.ts
+++ b/lib/bank.ts
@@ -45,6 +45,7 @@ export const api_route = {
     documents: "documents/"
 };
 
+// Other
 export const msg = {
     err: {
         "INTERNAL": "Don't worry, it's not your fault.",
@@ -52,16 +53,6 @@ export const msg = {
         "API_TIMEOUT_EXTRA": "The server is not responding and we can't hold the door open any longer, which is why you are seeing this message. Your connection to the server \"may\" not be stable, or the server \"may\" be busy or down at the moment.",
         "API_INVALID_RESPONSE": "We are unable to process your request right now. Try again later.",
         "API_INVALID_RESPONSE_EXTRA": "We HAVE received a response from the server, but it is not what we expected. It is \"possible\" that the server has triggered protection against your IP being temporarily blocked."
-    },
-
-    info: {
-        // ...
-    },
-
-    warn: {
-        // ...
     }
 };
-
-// Other
 export const timeout = 7000

--- a/lib/bank.ts
+++ b/lib/bank.ts
@@ -64,4 +64,4 @@ export const msg = {
 };
 
 // Other
-export const timeout = 5000
+export const timeout = 7000

--- a/lib/core/JSPError.ts
+++ b/lib/core/JSPError.ts
@@ -2,7 +2,7 @@ import {TError} from '../bank';
 
 export class JSPError extends Error {
     constructor(type: TError, msg: string, extra?: string) {
-        if (typeof extra !== "undefined") msg += "\n* " + extra;
+        if (extra) msg += "\n* " + extra;
 
         super(msg);
         this.name = "JSP" + type;

--- a/lib/core/JSPHTTP.ts
+++ b/lib/core/JSPHTTP.ts
@@ -7,26 +7,25 @@ export abstract class JSPHTTP {
     readonly #options;
 
     protected constructor(api_url: string | undefined, options: any) {
-        if (typeof api_url === "undefined") throw new JSPError("InternalError", msg.err.INTERNAL, msg.err.INTERNAL_EXTRA);
+        if (!api_url) throw new JSPError("InternalError", msg.err.INTERNAL, msg.err.INTERNAL_EXTRA);
 
         this.#api_url = api_url;
         this.#options = options;
     }
 
     protected run(method: TMethod, resource?: string, secret?: string, payload?: any) {
-        if (typeof resource === "undefined") resource = "";
-        const fetch = c(this.#api_url + resource, this.#options).option("method", method);
+        const fetch = c(this.#api_url + (resource ? resource : ""), this.#options).option("method", method);
 
         switch (method) {
             case "GET":
                 break;
 
             case "POST":
-                if (typeof payload !== "undefined") fetch.body(payload);
+                if (payload) fetch.body(payload);
                 break;
 
             case "DELETE":
-                if (typeof secret !== "undefined") fetch.header("secret", secret);
+                if (secret) fetch.header("secret", secret);
                 break;
 
             default:

--- a/lib/core/JSPHTTP.ts
+++ b/lib/core/JSPHTTP.ts
@@ -27,9 +27,6 @@ export abstract class JSPHTTP {
             case "DELETE":
                 if (secret) fetch.header("secret", secret);
                 break;
-
-            default:
-                throw new JSPError("InternalError", msg.err.INTERNAL, msg.err.INTERNAL_EXTRA);
         }
 
         return fetch.timeout(timeout).compress().send().catch((err) => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,3 @@
-import {JSP} from "./JSP";
+import JSP from "./JSP";
 
 export = JSP;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jspaste",
-  "version": "10.0.2",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jspaste",
-      "version": "10.0.2",
+      "version": "0.0.0",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "centra": "^2.6.0"
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@types/centra": "^2.2.0",
         "@types/jest": "^29.2.4",
-        "@types/node": "^18.11.12",
+        "@types/node": "^18.11.13",
         "@typescript-eslint/eslint-plugin": "^5.46.0",
         "@typescript-eslint/parser": "^5.46.0",
         "eslint": "^8.29.0",
@@ -1318,9 +1318,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.12.tgz",
-      "integrity": "sha512-FgD3NtTAKvyMmD44T07zz2fEf+OKwutgBCEVM8GcvMGVGaDktiLNTDvPwC/LUe3PinMW+X6CuLOF2Ui1mAlSXg==",
+      "version": "18.11.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
+      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -1891,9 +1891,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001436",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz",
-      "integrity": "sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==",
+      "version": "1.0.30001439",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
+      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
       "dev": true,
       "funding": [
         {
@@ -4747,9 +4747,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.0.tgz",
-      "integrity": "sha512-FIJe0msW9P7L9BTfvaJyvn1U1BVCNTL3w8O+PKIrCyiMLg+rIUGb4MbcgVZ10Lnm1uWXOTOWRNARjfXC1+M12Q==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.2.tgz",
+      "integrity": "sha512-orqIX5zkHyHKVsIBl8J5a2tnVikOAMte0DgOLViyW6McYuj45FG+cQPrXILhaifBSmy0D0hKbHg2RbgzFJcwTg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -6505,9 +6505,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.12.tgz",
-      "integrity": "sha512-FgD3NtTAKvyMmD44T07zz2fEf+OKwutgBCEVM8GcvMGVGaDktiLNTDvPwC/LUe3PinMW+X6CuLOF2Ui1mAlSXg==",
+      "version": "18.11.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
+      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
       "dev": true
     },
     "@types/prettier": {
@@ -6891,9 +6891,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001436",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz",
-      "integrity": "sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==",
+      "version": "1.0.30001439",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
+      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
       "dev": true
     },
     "centra": {
@@ -8906,9 +8906,9 @@
       }
     },
     "rollup": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.0.tgz",
-      "integrity": "sha512-FIJe0msW9P7L9BTfvaJyvn1U1BVCNTL3w8O+PKIrCyiMLg+rIUGb4MbcgVZ10Lnm1uWXOTOWRNARjfXC1+M12Q==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.2.tgz",
+      "integrity": "sha512-orqIX5zkHyHKVsIBl8J5a2tnVikOAMte0DgOLViyW6McYuj45FG+cQPrXILhaifBSmy0D0hKbHg2RbgzFJcwTg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prepublishOnly": "npm run test && npm run build",
     "test": "npm run build:check && jest --no-cache"
   },
-  "sideEffects": false,
+  "sideEffects": true,
   "types": "./dist/index.d.ts",
   "dependencies": {
     "centra": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jspaste",
-  "version": "10.0.2",
+  "version": "0.0.0",
   "description": "Powerful library to easily interact with JSPaste API",
   "license": "BSD-3-Clause-Clear",
   "author": "tnfAngel",
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@types/centra": "^2.2.0",
     "@types/jest": "^29.2.4",
-    "@types/node": "^18.11.12",
+    "@types/node": "^18.11.13",
     "@typescript-eslint/eslint-plugin": "^5.46.0",
     "@typescript-eslint/parser": "^5.46.0",
     "eslint": "^8.29.0",
@@ -89,7 +89,7 @@
     "roots": [
       "<rootDir>/test/"
     ],
-    "testTimeout": 60000
+    "testTimeout": 7000
   },
   "tsup": {
     "platform": "node",

--- a/test/JSP.test.ts
+++ b/test/JSP.test.ts
@@ -1,4 +1,4 @@
-import {JSP} from "../lib/JSP";
+import JSP from "../lib";
 
 jest.retryTimes(3, {logErrorsBeforeRetry: true});
 describe("JSP#", () => {

--- a/test/JSP.test.ts
+++ b/test/JSP.test.ts
@@ -9,8 +9,9 @@ describe("JSP#", () => {
     test(".publish()", async () => {
         const x = await jsp.publish("Lorem ipsum dolor sit amet");
 
-        expect(x).toBeDefined();
         expect(x).toBeInstanceOf(Object);
+        expect(x.res.resource).toBeDefined();
+        expect(x.res.secret).toBeDefined();
         expect(x.req.valid).toBeTruthy();
         console.debug(x)
 
@@ -21,8 +22,8 @@ describe("JSP#", () => {
     test(".access() -> valid", async () => {
         const x = await jsp.access(resource);
 
-        expect(x).toBeDefined();
         expect(x).toBeInstanceOf(Object);
+        expect(x.res.payload).toBeDefined();
         expect(x.req.valid).toBeTruthy();
         console.debug(x)
     });
@@ -30,8 +31,8 @@ describe("JSP#", () => {
     test(".access() -> invalid", async () => {
         const x = await jsp.access(".invalid.");
 
-        expect(x).toBeDefined();
         expect(x).toBeInstanceOf(Object);
+        expect(x.res.payload).toBeUndefined();
         expect(x.req.valid).toBeFalsy();
         console.debug(x)
     });
@@ -39,7 +40,6 @@ describe("JSP#", () => {
     test(".remove() -> valid", async () => {
         const x = await jsp.remove(resource, secret);
 
-        expect(x).toBeDefined();
         expect(x).toBeInstanceOf(Object);
         expect(x.req.valid).toBeTruthy();
         console.debug(x)
@@ -48,7 +48,6 @@ describe("JSP#", () => {
     test(".remove() -> invalid", async () => {
         const x = await jsp.remove(resource, ".invalid.");
 
-        expect(x).toBeDefined();
         expect(x).toBeInstanceOf(Object);
         expect(x.req.valid).toBeFalsy();
         console.debug(x)

--- a/test/JSP.test.ts
+++ b/test/JSP.test.ts
@@ -1,11 +1,12 @@
 import {JSP} from "../lib/JSP";
 
+jest.retryTimes(3, {logErrorsBeforeRetry: true});
 describe("JSP#", () => {
     const jsp = new JSP();
     let resource: string;
     let secret: string;
 
-    test("publish()", async () => {
+    test(".publish()", async () => {
         const x = await jsp.publish("Lorem ipsum dolor sit amet");
 
         expect(x).toBeDefined();
@@ -17,7 +18,7 @@ describe("JSP#", () => {
         secret = <string>x.res.secret
     });
 
-    test("access() -> valid", async () => {
+    test(".access() -> valid", async () => {
         const x = await jsp.access(resource);
 
         expect(x).toBeDefined();
@@ -26,8 +27,8 @@ describe("JSP#", () => {
         console.debug(x)
     });
 
-    test("access() -> invalid", async () => {
-        const x = await jsp.access(String(".invalid."));
+    test(".access() -> invalid", async () => {
+        const x = await jsp.access(".invalid.");
 
         expect(x).toBeDefined();
         expect(x).toBeInstanceOf(Object);
@@ -35,7 +36,7 @@ describe("JSP#", () => {
         console.debug(x)
     });
 
-    test("remove() -> valid", async () => {
+    test(".remove() -> valid", async () => {
         const x = await jsp.remove(resource, secret);
 
         expect(x).toBeDefined();
@@ -44,8 +45,8 @@ describe("JSP#", () => {
         console.debug(x)
     });
 
-    test("remove() -> invalid", async () => {
-        const x = await jsp.remove(resource, String(".invalid."));
+    test(".remove() -> invalid", async () => {
+        const x = await jsp.remove(resource, ".invalid.");
 
         expect(x).toBeDefined();
         expect(x).toBeInstanceOf(Object);

--- a/test/JSPError.test.ts
+++ b/test/JSPError.test.ts
@@ -1,11 +1,12 @@
 import {JSPError} from "../lib/core/JSPError";
 
-describe("JSPError", () => {
-    test("# (test error)", () => {
+describe("JSPError#", () => {
+    test("() -> test", () => {
         const x = "This is a test error";
+        const y = "This is the description of the test error";
 
         expect(() => {
-            throw new JSPError("TestError", x, "foobar");
+            throw new JSPError("TestError", x, y);
         }).toThrow(x);
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,17 +13,25 @@
     "declaration": true,
     "newLine": "lf",
     "outDir": "dist",
-    "pretty": true,
     "stripInternal": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "noPropertyAccessFromIndexSignature": true,
     "noEmit": true,
     "useDefineForClassFields": true,
     "isolatedModules": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "alwaysStrict": true,
+    "strictBindCallApply": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true
   },
   "include": [
     "lib/**/*.ts"


### PR DESCRIPTION
Este parche para JSPaste 10.0.3 incluirá arreglos contra el tiempo de espera para la respuesta del servidor, reintentos en la suite de tests en caso de que el servidor no responda las solicitudes en ese momento, un arreglo importante que impedía publicar JSPaste a NPM a vía CI, limpieza del CI de CodeQL y pequeños cambios menores estéticos y de funcionamiento interno.

Lo más probable este sea el último parche de la 10.0.x antes de que empiece el desarrollo de la 10.1.0